### PR TITLE
feat: track when connection goes offline

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import React, { render } from '@testing-library/react';
-import App from './App';
+import { App, Props } from './App';
 
 jest.mock('react-router-dom', () => ({
   Link: (): JSX.Element => <a />,
@@ -9,8 +9,12 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('./components/notification-banner', () => ({
   __esModule: true,
-  default: (): JSX.Element => <div />
+  default: (): JSX.Element => <div />,
 }));
+
+const defaultProps: Props = {
+  openConnection: jest.fn(),
+};
 
 describe('App', (): void => {
   afterAll((): void => {
@@ -18,6 +22,14 @@ describe('App', (): void => {
   });
 
   it('renders without error', (): void => {
-    expect(() => render(<App />)).not.toThrow();
+    expect(() => render(<App {...defaultProps} />)).not.toThrow();
+  });
+
+  it('calls to open a connection on mount', (): void => {
+    const spyOpenConnection = jest.fn();
+
+    render(<App openConnection={spyOpenConnection} />);
+
+    expect(spyOpenConnection).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link, Routes, Route } from 'react-router-dom';
-import { GlobalStyle } from './styles/global'
+import { connect } from 'react-redux';
 
+import { GlobalStyle } from './styles/global';
+import ConnectionState from './services/connection/connection.state';
 import IsinList from './views/isin-list';
 import IsinSearch from './views/isin-search';
 import { Plus } from './components/svg';
 
-import { BrandLogo, Container, Header, Nav, Main, SearchButton, NotificationBanner } from './App.css'
+import {
+  BrandLogo,
+  Container,
+  Header,
+  Nav,
+  Main,
+  SearchButton,
+  NotificationBanner,
+} from './App.css';
 
-export const App = () => {
+export interface Props {
+  openConnection: () => void;
+}
+
+export const App = ({ openConnection }: Props) => {
+  useEffect((): void => {
+    openConnection();
+  }, []);
+
   return (
     <>
       <Container>
@@ -35,4 +53,8 @@ export const App = () => {
   );
 };
 
-export default App;
+const mapDispatchToProps = {
+  openConnection: ConnectionState.actions.openConnectionRequest,
+};
+
+export default connect(null, mapDispatchToProps)(App);

--- a/src/services/connection/connection.saga.ts
+++ b/src/services/connection/connection.saga.ts
@@ -1,6 +1,10 @@
-import { all, call, select, put, takeLatest } from 'redux-saga/effects';
+import { all, call, select, put, takeLatest, take } from 'redux-saga/effects';
+import { eventChannel, EventChannel } from 'redux-saga';
 
+import bannerState from '../notification-banner/banner.state';
+import { BannerType } from '../notification-banner/banner.state.types';
 import connectionState from './connection.state';
+import { ConnectionAction } from './connection.state.types';
 
 /* istanbul ignore next */
 export const openSocket = (uri: string): Promise<WebSocket> =>
@@ -19,22 +23,77 @@ export const closeSocket = (socket: WebSocket): Promise<void> =>
     socket.close();
   });
 
+/* istanbul ignore next */
+export function monitorConnection(): EventChannel<unknown> {
+  return eventChannel((emit) => {
+    const onOnline = (): void =>
+      emit(connectionState.actions.connectionOnline());
+    const onOffline = (): void =>
+      emit(connectionState.actions.connectionOffline());
+
+    window.addEventListener('offline', onOffline);
+    window.addEventListener('online', onOnline);
+
+    return (): void => {
+      window.removeEventListener('offline', onOffline);
+      window.removeEventListener('online', onOnline);
+    };
+  });
+}
+
+export function* connectionLost(): Generator<unknown> {
+  yield put(
+    bannerState.actions.showBanner(
+      'Connection lost. You are offline!',
+      BannerType.ERROR,
+      4000
+    )
+  );
+}
+
+export function* connectionRegained(): Generator<unknown> {
+  yield put(
+    bannerState.actions.showBanner(
+      'Connection regained. You are back online!',
+      BannerType.SUCCESS
+    )
+  );
+}
+
 export function* establishConnection(): Generator<unknown> {
   try {
     const uri = 'ws://159.89.15.214:8080/';
-    const hasConnection = yield select(
-      connectionState.selectors.getIsConnected
+    const hasSocket = yield select(
+      connectionState.selectors.getSocket
     );
-
-    if (!hasConnection) {
+    
+    if (!hasSocket) {
       const socket = yield call(openSocket, uri);
-      
+
       yield put(
         connectionState.actions.openConnectionSuccess(socket as WebSocket)
       );
     }
   } catch (e: unknown) {
     yield put(connectionState.actions.openConnectionFailure(e as Error));
+    yield put(
+      bannerState.actions.showBanner('Connection failed', BannerType.ERROR)
+    );
+  }
+}
+
+export function* establishConnectionSuccess(): Generator<unknown> {
+  const channel = yield call(monitorConnection);
+
+  yield put(
+    bannerState.actions.showBanner('Connected successfully', BannerType.SUCCESS)
+  );
+
+  /* istanbul ignore next */
+  while (true) {
+    const action = yield take(channel as EventChannel<unknown>);
+
+    yield put(action as ConnectionAction);
   }
 }
 
@@ -42,10 +101,16 @@ export function* closeConnection(): Generator<unknown> {
   try {
     const socket = yield select(connectionState.selectors.getSocket);
     const hasConnection = socket !== null;
-    
+
     if (hasConnection) {
       yield call(closeSocket, socket as WebSocket);
       yield put(connectionState.actions.closeConnectionSuccess());
+      yield put(
+        bannerState.actions.showBanner(
+          'Connection closed successfully',
+          BannerType.SUCCESS
+        )
+      );
     }
   } catch (e: unknown) {
     yield put(connectionState.actions.closeConnectionFailure(e as Error));
@@ -58,7 +123,13 @@ function* rootSaga(): Generator<unknown> {
       connectionState.types.OPEN_CONNECTION_REQUEST,
       establishConnection
     ),
+    takeLatest(
+      connectionState.types.OPEN_CONNECTION_SUCCESS,
+      establishConnectionSuccess
+    ),
     takeLatest(connectionState.types.CLOSE_CONNECTION_REQUEST, closeConnection),
+    takeLatest(connectionState.types.CONNECTION_OFFLINE, connectionLost),
+    takeLatest(connectionState.types.CONNECTION_ONLINE, connectionRegained),
   ]);
 }
 

--- a/src/services/connection/connection.state.test.ts
+++ b/src/services/connection/connection.state.test.ts
@@ -69,6 +69,18 @@ describe('connection state', (): void => {
         }
       );
     });
+
+    it('returns the correct payload for CONNECTION_OFFLINE', (): void => {
+      expect(connectionState.actions.connectionOffline()).toEqual({
+        type: connectionState.types.CONNECTION_OFFLINE
+      });
+    });
+
+    it('returns the correct payload for CONNECTION_ONLINE', (): void => {
+      expect(connectionState.actions.connectionOnline()).toEqual({
+        type: connectionState.types.CONNECTION_ONLINE
+      });
+    });
   });
 
   describe('reducer', (): void => {
@@ -132,6 +144,32 @@ describe('connection state', (): void => {
         connectionState.actions.closeConnectionFailure(dummyError),
       );
       
+      expect(result).toEqual(expected);
+    });
+
+    it('sets the state with CONNECTION_OFFLINE', (): void => {
+      const expected: ConnectionState = {
+        ...dummyState,
+        connected: false,
+      };
+      const result: ConnectionState = connectionState.reducer(
+        dummyState,
+        connectionState.actions.connectionOffline()
+      );
+
+      expect(result).toEqual(expected);
+    });
+
+    it('sets the state with CONNECTION_ONLINE', (): void => {
+      const expected: ConnectionState = {
+        ...dummyState,
+        connected: true,
+      };
+      const result: ConnectionState = connectionState.reducer(
+        dummyState,
+        connectionState.actions.connectionOnline()
+      );
+
       expect(result).toEqual(expected);
     });
 

--- a/src/services/connection/connection.state.ts
+++ b/src/services/connection/connection.state.ts
@@ -9,6 +9,8 @@ const OPEN_CONNECTION_FAILURE = `${REDUCER_NAME}/OPEN_CONNECTION_FAILURE`;
 const CLOSE_CONNECTION_REQUEST = `${REDUCER_NAME}/CLOSE_CONNECTION_REQUEST`;
 const CLOSE_CONNECTION_SUCCESS = `${REDUCER_NAME}/CLOSE_CONNECTION_SUCCESS`;
 const CLOSE_CONNECTION_FAILURE = `${REDUCER_NAME}/CLOSE_CONNECTION_FAILURE`;
+const CONNECTION_OFFLINE = `${REDUCER_NAME}/CONNECTION_OFFLINE`;
+const CONNECTION_ONLINE = `${REDUCER_NAME}/CONNECTION_ONLINE`;
 
 /** Actions */
 const openConnectionRequest = (): ConnectionAction => ({
@@ -42,6 +44,14 @@ const closeConnectionFailure = (error: Error): ConnectionAction => ({
   payload: {
     error,
   },
+});
+
+const connectionOffline = (): ConnectionAction => ({
+  type: CONNECTION_OFFLINE
+})
+
+const connectionOnline = (): ConnectionAction => ({
+  type: CONNECTION_ONLINE
 });
 
 /** Reducer */
@@ -83,6 +93,18 @@ const reducer = (
         error: payload!.error!,
       };
     }
+    case CONNECTION_OFFLINE: {
+      return {
+        ...state,
+        connected: false,
+      }
+    }
+    case CONNECTION_ONLINE: {
+      return {
+        ...state,
+        connected: true
+      }
+    }
     default:
       return state;
   }
@@ -117,6 +139,8 @@ const connectionState = {
     CLOSE_CONNECTION_REQUEST,
     CLOSE_CONNECTION_SUCCESS,
     CLOSE_CONNECTION_FAILURE,
+    CONNECTION_OFFLINE,
+    CONNECTION_ONLINE,
   },
   selectors: {
     getSocket,
@@ -130,6 +154,8 @@ const connectionState = {
     closeConnectionRequest,
     closeConnectionSuccess,
     closeConnectionFailure,
+    connectionOffline,
+    connectionOnline,
   },
 };
 

--- a/src/services/isin-list/list.saga.ts
+++ b/src/services/isin-list/list.saga.ts
@@ -21,7 +21,7 @@ import bannerState from '../notification-banner/banner.state';
 export function subscribe(
   socket: WebSocket,
   company: Company
-): EventChannel<unknown> {
+): EventChannel<unknown> | null {
   return eventChannel((emit) => {
     const onMessage = ({ data }: { data: unknown }): void => {
       const stockData: StockData = JSON.parse(data as string);

--- a/src/views/isin-list/list.test.tsx
+++ b/src/views/isin-list/list.test.tsx
@@ -37,7 +37,6 @@ const instruments: Instrument[] = [
 ];
 
 const defaultProps: Props = {
-  openConnection: jest.fn(),
   unsubscribe: jest.fn(),
   instruments,
 };
@@ -45,14 +44,6 @@ const defaultProps: Props = {
 describe('<List />', (): void => {
   it('renders the component', (): void => {
     expect(() => render(<List {...defaultProps} />)).not.toThrow();
-  });
-
-  it('calls to open a connection on mount', (): void => {
-    const spyOpenConnection = jest.fn();
-    
-    render(<List {...defaultProps} openConnection={spyOpenConnection} />);
-
-    expect(spyOpenConnection).toHaveBeenCalledTimes(1);
   });
 
   it('calls to unsubscribe on press delete', async (): Promise<void> => {

--- a/src/views/isin-list/list.tsx
+++ b/src/views/isin-list/list.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { CombinedAppState } from '../../store.types';
 import ListState from '../../services/isin-list/list.state';
-import ConnectionState from '../../services/connection/connection.state';
 import { Instrument } from '../../services/isin-list/list.state.types';
 
 import {
@@ -14,17 +13,12 @@ import {
 } from './list.css';
 
 export interface Props {
-  openConnection: () => void;
   unsubscribe: (instrument: Instrument) => void;
   instruments: Instrument[];
 }
 
-export const List = ({ openConnection, unsubscribe, instruments }: Props): JSX.Element => {
+export const List = ({ unsubscribe, instruments }: Props): JSX.Element => {
   const shouldShowNoInstruments: boolean = instruments.length === 0;
-
-  useEffect((): void => {
-    openConnection();
-  }, []);
 
   return (
     <Container>
@@ -56,7 +50,6 @@ const mapStateToProps = (store: CombinedAppState) => ({
 });
 
 const mapDispatchToProps = {
-  openConnection: ConnectionState.actions.openConnectionRequest,
   unsubscribe: ListState.actions.unsubscribe,
   reset: ListState.actions.reset,
 };


### PR DESCRIPTION
**What is this?**

This PR adds offline detection functionality and tweaks the app accordingly for when a connection is lost. It has the following changes:

- updated the network saga to detect changes to internet connectivity and show a banner when the connection goes online or offline.
- fixed a bug where the app would crash in the event of adding an instrument when there was no active WebSocket connection.
- The main `<App />` component now manages making a WebSocket connection as opposed to the `<List />` component.