### PR TITLE
feat: ui tweaks and performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.7.2",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.7.13",
     "@types/react": "^17.0.20",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ export const App = ({ openConnection }: Props) => {
   useEffect((): void => {
     openConnection();
   }, []);
-
+  
   return (
     <>
       <Container>

--- a/src/components/instrument/instrument.test.tsx
+++ b/src/components/instrument/instrument.test.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 
+import { Company } from '../../services/isin-search/search.state.types';
 import InstrumentTile, { Props } from './instrument';
+
+const company: Company = {
+  isin: 'TEST123',
+  name: 'Test Company',
+  shortName: 'TST',
+  bookmarked: false,
+};
 
 const defaultProps: Props = {
   instrument: {
-    company: {
-      isin: 'TEST123',
-      name: 'Test Company',
-      shortName: 'TST',
-    },
+    company,
     stockData: {
       isin: 'TEST123',
       bid: 1.0,
@@ -45,6 +49,7 @@ describe('<InstrumentTile />', (): void => {
 
     await waitFor((): void => {
       expect(spyOnPressDelete).toHaveBeenCalledTimes(1);
+      expect(spyOnPressDelete).toHaveBeenCalledWith(company)
     });
   });
 });

--- a/src/components/instrument/instrument.tsx
+++ b/src/components/instrument/instrument.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 
 import { formattedCurrency } from '../../utils';
 
+import { Company } from '../../services/isin-search/search.state.types';
 import { Instrument } from '../../services/isin-list/list.state.types';
 import {
   Container,
@@ -18,7 +19,7 @@ export interface Props {
   className?: string;
   role?: string;
   instrument: Instrument;
-  onPressDelete: (instrument: Instrument) => void;
+  onPressDelete: (company: Company) => void;
 }
 
 const InstrumentTile = ({ className, role, instrument, onPressDelete }: Props): JSX.Element => {
@@ -27,7 +28,7 @@ const InstrumentTile = ({ className, role, instrument, onPressDelete }: Props): 
     stockData,
   } = instrument;
 
-  const handlePressDelete = useCallback((): void => onPressDelete(instrument), []);
+  const handlePressDelete = useCallback((): void => onPressDelete(instrument.company), []);
 
   return (
     <Container role={role} className={className} onClick={handlePressDelete}>

--- a/src/components/search-result/search-result.test.tsx
+++ b/src/components/search-result/search-result.test.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
+import { Company } from '../../services/isin-search/search.state.types';
 import SearchResult, { Props } from './search-result';
 
 const defaultProps: Props = {
-  isSubscribed: false,
+  onPress: jest.fn(),
   company: {
     name: 'Test Company',
     isin: 'IE12345678910',
-    shortName: 'TES'
+    shortName: 'TES',
+    bookmarked: false,
   }
 };
 
@@ -32,20 +34,25 @@ describe('<SearchResult />', (): void => {
     expect(spyOnPress).toHaveBeenCalledWith({
       name: 'Test Company',
       isin: 'IE12345678910',
-      shortName: 'TES'
+      shortName: 'TES',
+      bookmarked: false,
     });
   });
 
   describe('bookmark icon', (): void => {
     it('shows a filled bookmark icon when subscribed', (): void => {
-      const { getByTestId, queryByTestId } = render(<SearchResult {...defaultProps} isSubscribed />);
+      const bookmarkedCompany: Company = {
+        ...defaultProps.company,
+        bookmarked: true,
+      };
+      const { getByTestId, queryByTestId } = render(<SearchResult {...defaultProps} company={bookmarkedCompany} />);
 
       expect(getByTestId('bookmark-filled')).not.toBeNull();
       expect(queryByTestId('bookmark')).toBeNull();
     });
 
     it('shows an unfilled bookmark icon when not subscribed', (): void => {
-      const { getByTestId, queryByTestId } = render(<SearchResult {...defaultProps} isSubscribed={false} />);
+      const { getByTestId, queryByTestId } = render(<SearchResult {...defaultProps} />);
 
       expect(getByTestId('bookmark')).not.toBeNull();
       expect(queryByTestId('bookmark-filled')).toBeNull();

--- a/src/components/search-result/search-result.tsx
+++ b/src/components/search-result/search-result.tsx
@@ -6,14 +6,13 @@ import { BookmarkIcon, BookmarkFilledIcon, Container, CompanyDetails, Title } fr
 export interface Props {
   className?: string;
   company: Company;
-  isSubscribed: boolean;
-  onPress?: (company: Company) => void;
+  onPress: (company: Company) => void;
 }
 
-const SearchResult = ({ className, company, isSubscribed, onPress }: Props): JSX.Element => {
+const SearchResult = ({ className, company, onPress }: Props): JSX.Element => {
   const handleOnClick = useCallback((): void => {
-    !isSubscribed && onPress && onPress(company);
-  }, [company, isSubscribed]);
+    onPress(company);
+  }, [company]);
 
   return (
     <Container className={className} onClick={handleOnClick} role="button">
@@ -23,7 +22,7 @@ const SearchResult = ({ className, company, isSubscribed, onPress }: Props): JSX
       <CompanyDetails>
         {company.isin} / {company.shortName}
       </CompanyDetails>
-      {isSubscribed ? (
+      {company.bookmarked ? (
         <BookmarkFilledIcon />
       ) : (
         <BookmarkIcon />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
+import { Store } from 'redux';
 import { Provider } from 'react-redux';
 
-import store from './store';
-
+import createClientStore from './store';
 import App from './App';
+
+const store: Store = createClientStore();
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/services/connection/connection.saga.test.ts
+++ b/src/services/connection/connection.saga.test.ts
@@ -21,6 +21,7 @@ const mockState: CombinedAppState = {
     connected: false,
     error: null,
     socket: null,
+    listening: false,
   },
   banner: {
     type: BannerType.SUCCESS,

--- a/src/services/connection/connection.state.test.ts
+++ b/src/services/connection/connection.state.test.ts
@@ -8,6 +8,7 @@ describe('connection state', (): void => {
     error: null,
     socket: null,
     connected: false,
+    listening: false,
   };
 
   describe('actions', (): void => {
@@ -60,25 +61,34 @@ describe('connection state', (): void => {
     it('returns the correct payload for closeConnectionFailure', (): void => {
       const dummyError: Error = new Error('oops');
 
-      expect(connectionState.actions.closeConnectionFailure(dummyError)).toEqual(
-        {
-          type: connectionState.types.CLOSE_CONNECTION_FAILURE,
-          payload: {
-            error: dummyError,
-          },
-        }
-      );
+      expect(
+        connectionState.actions.closeConnectionFailure(dummyError)
+      ).toEqual({
+        type: connectionState.types.CLOSE_CONNECTION_FAILURE,
+        payload: {
+          error: dummyError,
+        },
+      });
     });
 
     it('returns the correct payload for CONNECTION_OFFLINE', (): void => {
       expect(connectionState.actions.connectionOffline()).toEqual({
-        type: connectionState.types.CONNECTION_OFFLINE
+        type: connectionState.types.CONNECTION_OFFLINE,
       });
     });
 
     it('returns the correct payload for CONNECTION_ONLINE', (): void => {
       expect(connectionState.actions.connectionOnline()).toEqual({
-        type: connectionState.types.CONNECTION_ONLINE
+        type: connectionState.types.CONNECTION_ONLINE,
+      });
+    });
+
+    it('returns the correct payload for SET_IS_LISTENING', (): void => {
+      expect(connectionState.actions.setIsListening(true)).toEqual({
+        type: connectionState.types.SET_IS_LISTENING,
+        payload: {
+          listening: true,
+        },
       });
     });
   });
@@ -141,9 +151,9 @@ describe('connection state', (): void => {
       };
       const result: ConnectionState = connectionState.reducer(
         dummyState,
-        connectionState.actions.closeConnectionFailure(dummyError),
+        connectionState.actions.closeConnectionFailure(dummyError)
       );
-      
+
       expect(result).toEqual(expected);
     });
 
@@ -173,6 +183,19 @@ describe('connection state', (): void => {
       expect(result).toEqual(expected);
     });
 
+    it('sets the state with SET_IS_LISTENING', (): void => {
+      const expected: ConnectionState = {
+        ...dummyState,
+        listening: true,
+      };
+      const result: ConnectionState = connectionState.reducer(
+        dummyState,
+        connectionState.actions.setIsListening(true)
+      );
+
+      expect(result).toEqual(expected);
+    });
+
     it('returns the default state with no type match', (): void => {
       const expected: ConnectionState = dummyState;
       const result: ConnectionState = connectionState.reducer(undefined, {
@@ -196,11 +219,12 @@ describe('connection state', (): void => {
         connected: false,
         error: null,
         socket: null,
+        listening: false,
       },
       banner: {
         type: BannerType.SUCCESS,
-        isShowing: false
-      }
+        isShowing: false,
+      },
     };
 
     it('getSocket', (): void => {
@@ -213,6 +237,10 @@ describe('connection state', (): void => {
 
     it('getError', (): void => {
       expect(connectionState.selectors.getError(appState)).toBeNull();
+    });
+
+    it('getIsListening', (): void => {
+      expect(connectionState.selectors.getIsListening(appState)).toEqual(false);
     });
   });
 });

--- a/src/services/connection/connection.state.types.ts
+++ b/src/services/connection/connection.state.types.ts
@@ -1,6 +1,7 @@
 export interface Payload {
   socket?: WebSocket | null;
   error?: Error | null;
+  listening?: boolean;
 }
 
 export interface ConnectionAction {
@@ -11,5 +12,6 @@ export interface ConnectionAction {
 export interface ConnectionState {
   socket: WebSocket | null;
   connected: boolean;
+  listening: boolean;
   error: Error | null;
 }

--- a/src/services/isin-list/list.saga.ts
+++ b/src/services/isin-list/list.saga.ts
@@ -10,7 +10,6 @@ import {
 import { eventChannel, EventChannel } from 'redux-saga';
 
 import { Company } from '../isin-search/search.state.types';
-import { Instrument } from '../isin-list/list.state.types';
 import { ListAction, StockData } from './list.state.types';
 import { BannerType } from '../notification-banner/banner.state.types';
 import connectionState from '../connection/connection.state';
@@ -20,7 +19,7 @@ import bannerState from '../notification-banner/banner.state';
 /* istanbul ignore next */
 export function subscribe(
   socket: WebSocket,
-  company: Company
+  company: Company,
 ): EventChannel<unknown> | null {
   return eventChannel((emit) => {
     const onMessage = ({ data }: { data: unknown }): void => {
@@ -33,26 +32,67 @@ export function subscribe(
     socket.addEventListener('message', onMessage);
     socket.send(payload);
 
-    return (): void => socket.removeEventListener('message', onMessage);
+    return (): void => {
+      socket.removeEventListener('message', onMessage);
+      emit(connectionState.actions.setIsListening(false));
+    }
   });
 }
 
 function* handleUnsubscribeInstrument(action: ListAction): Generator<unknown> {
   const socket = yield select(connectionState.selectors.getSocket);
-  const instrument: Instrument = action.payload!.instrument!;
-  const payload = JSON.stringify({ unsubscribe: instrument.company.isin });
+  const company: Company = action.payload!.company!;
+  const payload = JSON.stringify({ unsubscribe: company.isin });
 
   (socket as WebSocket).send(payload);
 
   yield delay(200);
-  yield put(listState.actions.removeInstrument(instrument));
+  yield put(listState.actions.removeInstrument(company));
   yield put(
     bannerState.actions.showBanner(
-      'Unsubscribed successfully!',
+      'Unsubscribed successfully and removed!',
       BannerType.SUCCESS,
       2000
     )
   );
+}
+
+function* handleUnsubscribeAllInstruments(): Generator<unknown> {
+  const socket = yield select(connectionState.selectors.getSocket);
+  const subscribedIsins = yield select(
+    listState.selectors.getSubscribedInstrumentIsins
+  );
+  const payloads: string[] = (subscribedIsins as string[]).map(
+    (isin: string): string => JSON.stringify({ unsubscribe: isin })
+  );
+  
+  try {
+    yield all(
+      payloads.map((payload: string): void =>
+        (socket as WebSocket).send(payload)
+      )
+    );
+  } finally {
+    yield put(listState.actions.updateInstrumentSubscriptions(false));
+  }
+}
+
+function* handleResubscribeAllInstruments(): Generator<unknown> {
+  const socket = yield select(connectionState.selectors.getSocket);
+  const unSubscribedIsins = yield select(
+    listState.selectors.getUnsubscribedInstrumentIsins
+  );
+  const payloads: string[] = (unSubscribedIsins as string[]).map(
+    (isin: string): string => JSON.stringify({ subscribe: isin })
+  );
+
+  try {
+    yield all(
+      payloads.map((payload: string): void => (socket as WebSocket).send(payload))
+    )
+  } finally {
+    yield put(listState.actions.updateInstrumentSubscriptions(true));
+  }
 }
 
 /* istanbul ignore next */
@@ -61,6 +101,7 @@ function* handleOnInstrumentAdded(action: ListAction): Generator<unknown> {
   const company: Company = action.payload!.company!;
   const channel = yield call(subscribe, socket as WebSocket, company);
 
+  yield put(connectionState.actions.setIsListening(true))
   yield put(
     bannerState.actions.showBanner(
       'Subscription successful!',
@@ -71,7 +112,7 @@ function* handleOnInstrumentAdded(action: ListAction): Generator<unknown> {
 
   while (true) {
     const action = yield take(channel as EventChannel<unknown>);
-
+  
     yield put(action as ListAction);
   }
 }
@@ -82,6 +123,14 @@ function* rootSaga(): Generator<unknown> {
     takeLatest(
       listState.types.UNSUBSCRIBE_REQUEST,
       handleUnsubscribeInstrument
+    ),
+    takeLatest(
+      listState.types.UNSUBSCRIBE_ALL_REQUEST,
+      handleUnsubscribeAllInstruments
+    ),
+    takeLatest(
+      listState.types.RESUBSCRIBE_ALL_REQUEST,
+      handleResubscribeAllInstruments
     ),
   ]);
 }

--- a/src/services/isin-list/list.state.ts
+++ b/src/services/isin-list/list.state.ts
@@ -1,5 +1,8 @@
+import { createSelector } from '@reduxjs/toolkit';
+
 import {
   Instrument,
+  Instruments,
   ListAction,
   ListState,
   StockData,
@@ -14,6 +17,9 @@ const ADD_INSTRUMENT = `${REDUCER_NAME}/ADD_INSTRUMENT`;
 const UPDATE_INSTRUMENT = `${REDUCER_NAME}/UPDATE_INSTRUMENT`;
 const REMOVE_INSTRUMENT = `${REDUCER_NAME}/REMOVE_INSTRUMENT`;
 const UNSUBSCRIBE_REQUEST = `${REDUCER_NAME}/UNSUBSCRIBE_REQUEST`;
+const UNSUBSCRIBE_ALL_REQUEST = `${REDUCER_NAME}/UNSUBSCRIBE_ALL_REQUEST`;
+const RESUBSCRIBE_ALL_REQUEST = `${REDUCER_NAME}/RESUBSCRIBE_ALL_REQUEST`;
+const UPDATE_INSTRUMENT_SUBSCRIPTIONS = `${REDUCER_NAME}/UPDATE_INSTRUMENT_SUBSCRIPTIONS`;
 const RESET = `${REDUCER_NAME}/RESET`;
 
 /** Actions */
@@ -31,17 +37,32 @@ const updateInstrument = (stockData: StockData): ListAction => ({
   },
 });
 
-const removeInstrument = (instrument: Instrument): ListAction => ({
+const removeInstrument = (company: Company): ListAction => ({
   type: REMOVE_INSTRUMENT,
   payload: {
-    instrument,
+    company,
   },
 });
 
-const unsubscribe = (instrument: Instrument): ListAction => ({
+const unsubscribe = (company: Company): ListAction => ({
   type: UNSUBSCRIBE_REQUEST,
   payload: {
-    instrument,
+    company,
+  },
+});
+
+const unsubscribeAll = (): ListAction => ({
+  type: UNSUBSCRIBE_ALL_REQUEST,
+});
+
+const resubscribeAll = (): ListAction => ({
+  type: RESUBSCRIBE_ALL_REQUEST
+});
+
+const updateInstrumentSubscriptions = (subscribed: boolean): ListAction => ({
+  type: UPDATE_INSTRUMENT_SUBSCRIPTIONS,
+  payload: {
+    subscribed
   }
 });
 
@@ -62,13 +83,16 @@ const reducer = (
 
   switch (type) {
     case UPDATE_INSTRUMENT: {
-      return handleUpdateInstrument(state, payload!.stockData!);
+      return handleUpdateInstrumentStockData(state, payload!.stockData!);
     }
     case ADD_INSTRUMENT: {
       return handleAddInstrument(state, payload!.company!);
     }
     case REMOVE_INSTRUMENT: {
-      return handleRemoveInstrument(state, payload!.instrument!);
+      return handleRemoveInstrument(state, payload!.company!);
+    }
+    case UPDATE_INSTRUMENT_SUBSCRIPTIONS: {
+      return handleUpdateInstrumentsSubscribed(state, payload!.subscribed!);
     }
     case RESET: {
       return initialState;
@@ -80,24 +104,39 @@ const reducer = (
 };
 
 /** Redux state update utilities */
-export const handleUpdateInstrument = (
+export const handleUpdateInstrumentStockData = (
   state: ListState,
   stockData: StockData
-): ListState => {
-  const instrumentToUpdate: Instrument = state.instruments[stockData.isin];
-  const updatedInstrument: Instrument = {
-    ...instrumentToUpdate,
-    stockData,
-    subscribed: true,
-  };
+): ListState => ({
+  ...state,
+  instruments: {
+    ...state.instruments,
+    [stockData.isin]: {
+      ...state.instruments[stockData.isin],
+      stockData,
+      subscribed: true,
+    },
+  },
+});
 
+export const handleUpdateInstrumentsSubscribed = (
+  state: ListState,
+  subscribed: boolean
+): ListState => {
+  const { instruments } = state;
+  const unsubscribed: Instruments = Object.values(instruments)
+    .map((instrument: Instrument): Instrument => ({ ...instrument, subscribed }))
+    .reduce((acc: Instruments, curr: Instrument ): Instruments => {
+      return {
+        ...acc,
+        [curr.company.isin]: curr
+      } 
+    }, {});
+  
   return {
     ...state,
-    instruments: {
-      ...state.instruments,
-      [stockData.isin]: updatedInstrument,
-    },
-  };
+    instruments: unsubscribed
+  }
 };
 
 export const handleAddInstrument = (
@@ -126,9 +165,9 @@ export const handleAddInstrument = (
 
 export const handleRemoveInstrument = (
   state: ListState,
-  instrument: Instrument
+  company: Company
 ): ListState => {
-  delete state.instruments[instrument.company.isin];
+  delete state.instruments[company.isin];
 
   return {
     ...state,
@@ -137,8 +176,41 @@ export const handleRemoveInstrument = (
 };
 
 /** Selectors */
-const getInstruments = ({ list }: { list: ListState }): Instrument[] =>
-  Object.values(list.instruments);
+const instrumentsSelector = ({
+  list: { instruments },
+}: {
+  list: ListState;
+}): { [index: string]: Instrument } => instruments;
+
+const selectInstruments = createSelector(
+  instrumentsSelector,
+  (instruments: { [index: string]: Instrument }): Instrument[] =>
+    Object.values(instruments)
+);
+
+const selectInstrumentIsins = createSelector(
+  instrumentsSelector,
+  (instruments: { [index: string]: Instrument }): string[] =>
+    Object.values(instruments).map(
+      ({ company: { isin } }: Instrument): string => isin
+    )
+);
+
+const selectSubscribedIsins = createSelector(
+  instrumentsSelector,
+  (instruments: { [index: string]: Instrument }): string[] =>
+    Object.values(instruments)
+      .filter(({ subscribed }: Instrument): boolean => subscribed)
+      .map(({ company: { isin } }: Instrument): string => isin)
+);
+
+const selectUnsubscribedIsins = createSelector(
+  instrumentsSelector,
+  (instruments: { [index: string]: Instrument }): string[] =>
+    Object.values(instruments)
+      .filter(({ subscribed }: Instrument): boolean => !subscribed)
+      .map(({ company: { isin } }: Instrument): string => isin)
+);
 
 const listState = {
   name: REDUCER_NAME,
@@ -148,15 +220,24 @@ const listState = {
     UPDATE_INSTRUMENT,
     REMOVE_INSTRUMENT,
     UNSUBSCRIBE_REQUEST,
+    UNSUBSCRIBE_ALL_REQUEST,
+    RESUBSCRIBE_ALL_REQUEST,
+    UPDATE_INSTRUMENT_SUBSCRIPTIONS,
     RESET,
   },
   selectors: {
-    getInstruments,
+    getInstruments: selectInstruments,
+    getInstrumentIsins: selectInstrumentIsins,
+    getSubscribedInstrumentIsins: selectSubscribedIsins,
+    getUnsubscribedInstrumentIsins: selectUnsubscribedIsins,
   },
   actions: {
     addInstrument,
     removeInstrument,
     unsubscribe,
+    unsubscribeAll,
+    resubscribeAll,
+    updateInstrumentSubscriptions,
     updateInstrument,
     reset,
   },

--- a/src/services/isin-list/list.state.types.ts
+++ b/src/services/isin-list/list.state.types.ts
@@ -17,10 +17,11 @@ export interface Payload {
   company?: Company;
   instrument?: Instrument;
   stockData?: StockData;
+  subscribed?: boolean;
 }
 
 export interface Instruments {
-  [index: string]: Instrument
+  [index: string]: Instrument;
 }
 
 export interface ListAction {
@@ -29,5 +30,6 @@ export interface ListAction {
 }
 
 export interface ListState {
-  instruments: Instruments
+  instruments: Instruments;
+  counter?: number;
 }

--- a/src/services/isin-search/search.state.test.ts
+++ b/src/services/isin-search/search.state.test.ts
@@ -2,7 +2,7 @@ import isins from '../../assets/isins.json';
 
 import { CombinedAppState } from '../../store.types';
 import { BannerType } from '../notification-banner/banner.state.types';
-import searchState, { handleUpdateSearchTerm } from './search.state';
+import searchState from './search.state';
 import { Company, SearchAction, SearchState } from './search.state.types';
 
 describe('search state', (): void => {
@@ -27,18 +27,7 @@ describe('search state', (): void => {
     it('sets the state with UPDATE_SEARCH_TERM', (): void => {
       const dummyState: SearchState = {
         searchTerm: '',
-        companies: [
-          {
-            name: 'Company Einz',
-            shortName: 'EIN',
-            isin: 'DE123456',
-          },
-          {
-            name: 'Comhlacht a Haon',
-            shortName: 'COM',
-            isin: 'IE78910',
-          },
-        ],
+        companies: [],
       };
       const result: SearchState = searchState.reducer(
         dummyState,
@@ -82,38 +71,11 @@ describe('search state', (): void => {
     });
   });
 
-  describe('reducer utils', (): void => {
-    const searchState: SearchState = {
-      companies: [],
-      searchTerm: '',
-    };
-
-    it('handleUpdateSearchTerm with empty search term', (): void => {
-      expect(handleUpdateSearchTerm(searchState, '')).toEqual({
-        ...searchState,
-        companies: isins as Company[],
-      });
-    });
-
-    it('handleUpdateSearchTerm with a search term', (): void => {
-      expect(handleUpdateSearchTerm(searchState, 'fox')).toEqual({
-        searchTerm: 'fox',
-        companies: [
-          {
-            name: 'Foxconn',
-            shortName: 'FXCOF',
-            isin: 'TW0002354008',
-          },
-        ],
-      });
-    });
-  });
-
   describe('selectors', (): void => {
     const searchTerm = 'Test search term';
     const companies: Company[] = [
-      { name: 'Company one', shortName: 'ONE', isin: 'IE1' },
-      { name: 'Company two', shortName: 'TWO', isin: 'IE2' },
+      { name: 'Company one', shortName: 'ONE', isin: 'IE1', bookmarked: false },
+      { name: 'Company two', shortName: 'TWO', isin: 'IE2', bookmarked: false },
     ];
     const appState: CombinedAppState = {
       search: {
@@ -127,6 +89,7 @@ describe('search state', (): void => {
         connected: false,
         error: null,
         socket: null,
+        listening: false,
       },
       banner: {
         type: BannerType.SUCCESS,
@@ -139,7 +102,13 @@ describe('search state', (): void => {
     });
 
     it('getCompanies', (): void => {
-      expect(searchState.selectors.getCompanies(appState)).toEqual(companies);
+      expect(searchState.selectors.getCompanies({
+        ...appState,
+        search: {
+          companies,
+          searchTerm: 'one'
+        }
+      })).toEqual([companies[0]]);
     });
   });
 });

--- a/src/services/isin-search/search.state.types.ts
+++ b/src/services/isin-search/search.state.types.ts
@@ -2,6 +2,7 @@ export interface Company {
   name: string;
   shortName: string;
   isin: string;
+  bookmarked: boolean;
 }
 
 export interface Payload {

--- a/src/services/notification-banner/banner.saga.test.ts
+++ b/src/services/notification-banner/banner.saga.test.ts
@@ -17,6 +17,7 @@ const mockState: CombinedAppState = {
     connected: false,
     error: null,
     socket: null,
+    listening: false,
   },
   banner: {
     type: BannerType.SUCCESS,

--- a/src/services/notification-banner/banner.state.test.ts
+++ b/src/services/notification-banner/banner.state.test.ts
@@ -91,6 +91,7 @@ describe('banner state', (): void => {
         connected: false,
         error: null,
         socket: null,
+        listening: false,
       },
       banner: {
         type: BannerType.SUCCESS,

--- a/src/services/notification-banner/banner.state.ts
+++ b/src/services/notification-banner/banner.state.ts
@@ -1,3 +1,5 @@
+import { createSelector } from '@reduxjs/toolkit';
+
 import { BannerAction, BannerState, BannerType } from './banner.state.types';
 
 const REDUCER_NAME = `banner`;
@@ -7,13 +9,17 @@ const SHOW_BANNER = `${REDUCER_NAME}/SHOW_BANNER`;
 const HIDE_BANNER = `${REDUCER_NAME}/HIDE_BANNER`;
 
 /** Actions */
-const showBanner = (message: string, type: BannerType, delay = 2000): BannerAction => ({
+const showBanner = (
+  message: string,
+  type: BannerType,
+  delay = 2000
+): BannerAction => ({
   type: SHOW_BANNER,
   payload: {
     message,
     type,
     delay,
-  }
+  },
 });
 
 const hideBanner = (): BannerAction => ({
@@ -33,14 +39,14 @@ const reducer = (
 ): BannerState => {
   const { type, payload } = action;
 
-  switch(type) {
+  switch (type) {
     case SHOW_BANNER: {
       return {
         ...state,
         isShowing: true,
         message: payload!.message!,
         type: payload!.type!,
-      }
+      };
     }
     case HIDE_BANNER: {
       return {
@@ -48,7 +54,7 @@ const reducer = (
         isShowing: false,
         message: undefined,
         type: BannerType.SUCCESS,
-      }
+      };
     }
     default: {
       return state;
@@ -57,27 +63,41 @@ const reducer = (
 };
 
 /** Selectors */
-const getMessage = ({ banner }: { banner: BannerState }): string | undefined => banner.message;
-const getType = ({ banner }: { banner: BannerState }): BannerType => banner.type;
-const getIsShowing = ({ banner }: { banner: BannerState }): boolean => banner.isShowing;
+const isShowingSelector = ({ banner: { isShowing } }: { banner: BannerState }): boolean => isShowing;
+const messageSelector = ({ banner: { message } }: { banner: BannerState }): string | undefined => message;
+const typeSelector = ({ banner: { type } }: { banner: BannerState }): BannerType => type;
+
+const selectIsShowing = createSelector(
+  isShowingSelector,
+  (isShowing: boolean): boolean => isShowing
+);
+
+const selectMessage = createSelector(
+  messageSelector,
+  (message: string | undefined): string | undefined => message
+);
+
+const selectType = createSelector(
+  typeSelector,
+  (type: BannerType): BannerType => type
+);
 
 const bannerState = {
   name: REDUCER_NAME,
   reducer,
   types: {
     SHOW_BANNER,
-    HIDE_BANNER
+    HIDE_BANNER,
   },
   selectors: {
-    getMessage,
-    getType,
-    getIsShowing,
+    getMessage: selectMessage,
+    getType: selectType,
+    getIsShowing: selectIsShowing,
   },
   actions: {
     showBanner,
-    hideBanner
-  }
+    hideBanner,
+  },
 };
 
 export default bannerState;
-

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,11 +15,14 @@ const rootReducer: Reducer<CombinedAppState, ReduxAction> = combineReducers({
   list: listState.reducer
 });
 
-const sagaMiddleware: SagaMiddleware = createSagaMiddleware();
+export const createClientStore = (): Store => {
+  const sagaMiddleware: SagaMiddleware = createSagaMiddleware();
+  const store: Store = createStore(rootReducer, applyMiddleware(sagaMiddleware));
 
-const store: Store = createStore(rootReducer, applyMiddleware(sagaMiddleware));
+  sagaMiddleware.run(rootSaga);
 
-sagaMiddleware.run(rootSaga);
+  return store;
+};
 
-export default store;
+export default createClientStore;
 

--- a/src/views/isin-list/list.test.tsx
+++ b/src/views/isin-list/list.test.tsx
@@ -11,6 +11,7 @@ const instruments: Instrument[] = [
       name: 'Test',
       shortName: 'TST',
       isin: 'IE123',
+      bookmarked: false,
     },
     stockData: {
       ask: 1.0,
@@ -25,6 +26,7 @@ const instruments: Instrument[] = [
       name: 'Other',
       shortName: 'OTH',
       isin: 'IE456',
+      bookmarked: false,
     },
     stockData: {
       ask: 2.0,
@@ -38,12 +40,25 @@ const instruments: Instrument[] = [
 
 const defaultProps: Props = {
   unsubscribe: jest.fn(),
+  unsubscribeAll: jest.fn(),
+  resubscribeAll: jest.fn(),
   instruments,
 };
 
 describe('<List />', (): void => {
   it('renders the component', (): void => {
     expect(() => render(<List {...defaultProps} />)).not.toThrow();
+  });
+
+  it('resubscribes and unsubscribes instrument feeds on mount / unmount', (): void => {
+    const spyResubscribeAll = jest.fn();
+    const spyUnsubscribeAll = jest.fn();
+    const { unmount } = render(<List {...defaultProps} unsubscribeAll={spyUnsubscribeAll} resubscribeAll={spyResubscribeAll} />);
+
+    unmount();
+
+    expect(spyResubscribeAll).toHaveBeenCalledTimes(1);
+    expect(spyUnsubscribeAll).toHaveBeenCalledTimes(1);
   });
 
   it('calls to unsubscribe on press delete', async (): Promise<void> => {
@@ -55,7 +70,7 @@ describe('<List />', (): void => {
 
     await waitFor((): void => {
       expect(spyUnsubscribe).toHaveBeenCalledTimes(1);
-      expect(spyUnsubscribe).toHaveBeenCalledWith(instruments[0]);
+      expect(spyUnsubscribe).toHaveBeenCalledWith(instruments[0].company);
     });
   });
 

--- a/src/views/isin-list/list.tsx
+++ b/src/views/isin-list/list.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { memo, useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { CombinedAppState } from '../../store.types';
 import ListState from '../../services/isin-list/list.state';
+import { Company } from '../../services/isin-search/search.state.types';
 import { Instrument } from '../../services/isin-list/list.state.types';
+import { Props as InstrumentTileProps } from '../../components/instrument/instrument';
 
 import {
   Container,
@@ -13,12 +15,31 @@ import {
 } from './list.css';
 
 export interface Props {
-  unsubscribe: (instrument: Instrument) => void;
+  unsubscribe: (company: Company) => void;
+  unsubscribeAll: () => void;
+  resubscribeAll: () => void;
   instruments: Instrument[];
 }
 
-export const List = ({ unsubscribe, instruments }: Props): JSX.Element => {
+const MemoInstrumentItem = memo(
+  (props: InstrumentTileProps): JSX.Element => <InstrumentItem {...props} />
+);
+
+MemoInstrumentItem.displayName = 'InstrumentTile';
+
+export const List = ({
+  unsubscribe,
+  unsubscribeAll,
+  resubscribeAll,
+  instruments,
+}: Props): JSX.Element => {
   const shouldShowNoInstruments: boolean = instruments.length === 0;
+
+  useEffect((): (() => void) => {
+    resubscribeAll();
+
+    return (): void => unsubscribeAll();
+  }, []);
 
   return (
     <Container>
@@ -30,7 +51,7 @@ export const List = ({ unsubscribe, instruments }: Props): JSX.Element => {
         <InstrumentTileList>
           {instruments.map(
             (instrument: Instrument): JSX.Element => (
-              <InstrumentItem
+              <MemoInstrumentItem
                 role="instrument"
                 key={instrument.company.isin}
                 instrument={instrument}
@@ -51,6 +72,8 @@ const mapStateToProps = (store: CombinedAppState) => ({
 
 const mapDispatchToProps = {
   unsubscribe: ListState.actions.unsubscribe,
+  unsubscribeAll: ListState.actions.unsubscribeAll,
+  resubscribeAll: ListState.actions.resubscribeAll,
   reset: ListState.actions.reset,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,16 @@
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.1.0.tgz#0e81ce56b4883b4b2a3001ebe1ab298b84237204"
   integrity sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg==
 
+"@reduxjs/toolkit@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.7.2.tgz#b428aaef92582379464f9de698dbb71957eafb02"
+  integrity sha512-wwr3//Ar8ZhM9bS58O+HCIaMlR4Y6SNHfuszz9hKnQuFIKvwaL3Kmjo6fpDKUOjo4Lv54Yi299ed8rofCJ/Vjw==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.0"
   resolved "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz"
@@ -7611,6 +7621,11 @@ redux-saga@^1.1.3:
   dependencies:
     "@redux-saga/core" "^1.1.3"
 
+redux-thunk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
 redux@^4.0.0, redux@^4.0.4, redux@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
@@ -7714,6 +7729,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
**What is this?**

This PR adds some tweaks to improve the UX and has some performance improvements as well, as follows:
- Selectors now wrapped in `createSelector` as part of the [ReduxJS toolkit](https://redux-toolkit.js.org/) to memoize selectors and improve performance.
- Instrument and search result components are now memoized, so as to prevent unnecessary re-renders.
- Bookmarking is now possible from the search result view as well as the list view.
- The main <App /> component now establishes a WebSocket connection.
- Feeds are unsubscribed from / resubscribed to when the list component is mounted and unmounted, to prevent unnecessary state updates.