### PR TITLE
fix: ensure check on instrument before updating it

### DIFF
--- a/src/services/isin-list/list.saga.ts
+++ b/src/services/isin-list/list.saga.ts
@@ -112,7 +112,7 @@ function* handleOnInstrumentAdded(action: ListAction): Generator<unknown> {
 
   while (true) {
     const action = yield take(channel as EventChannel<unknown>);
-  
+
     yield put(action as ListAction);
   }
 }

--- a/src/services/isin-list/list.state.test.ts
+++ b/src/services/isin-list/list.state.test.ts
@@ -104,23 +104,52 @@ describe('list state', (): void => {
       expect(result).toEqual(expected);
     });
 
-    it('sets the state with UPDATE_INSTRUMENT', (): void => {
-      const stateWithInstrument: ListState = {
-        ...dummyState,
-        instruments: {
-          ['IE123456']: instrument,
-        },
-      };
-      const result: ListState = listState.reducer(
-        stateWithInstrument,
-        listState.actions.updateInstrument(stockData)
-      );
-      const expected: ListState = handleUpdateInstrumentStockData(
-        stateWithInstrument,
-        stockData
-      );
+    describe('updating instrument', (): void => {
+      it('sets the state with UPDATE_INSTRUMENT', (): void => {
+        const stateWithInstrument: ListState = {
+          ...dummyState,
+          instruments: {
+            ['IE123456']: instrument,
+          },
+        };
+        const result: ListState = listState.reducer(
+          stateWithInstrument,
+          listState.actions.updateInstrument(stockData)
+        );
+        const expected: ListState = handleUpdateInstrumentStockData(
+          stateWithInstrument,
+          stockData
+        );
+  
+        expect(result).toEqual(expected);
+      });
 
-      expect(result).toEqual(expected);
+      it('sets the state with UPDATE_INSTRUMENT when the instrument does not exist', (): void => {
+        const stateWithInstrument: ListState = {
+          ...dummyState,
+          instruments: {
+            ['IE123456']: instrument,
+          },
+        };
+        const result: ListState = listState.reducer(
+          stateWithInstrument,
+          listState.actions.updateInstrument({
+            ...stockData,
+            isin: 'IE7891011',
+          })
+        );
+        const expected: ListState = handleUpdateInstrumentStockData(
+          stateWithInstrument,
+          {
+            bid: 0,
+            ask: 0,
+            price: 0,
+            isin: 'IE7891011',
+          }
+        );
+
+        expect(result).toEqual(expected);
+      });
     });
 
     it('sets the state with REMOVE_INSTRUMENT', (): void => {

--- a/src/services/isin-list/list.state.ts
+++ b/src/services/isin-list/list.state.ts
@@ -56,14 +56,14 @@ const unsubscribeAll = (): ListAction => ({
 });
 
 const resubscribeAll = (): ListAction => ({
-  type: RESUBSCRIBE_ALL_REQUEST
+  type: RESUBSCRIBE_ALL_REQUEST,
 });
 
 const updateInstrumentSubscriptions = (subscribed: boolean): ListAction => ({
   type: UPDATE_INSTRUMENT_SUBSCRIPTIONS,
   payload: {
-    subscribed
-  }
+    subscribed,
+  },
 });
 
 const reset = (): ListAction => ({
@@ -107,17 +107,25 @@ const reducer = (
 export const handleUpdateInstrumentStockData = (
   state: ListState,
   stockData: StockData
-): ListState => ({
-  ...state,
-  instruments: {
-    ...state.instruments,
-    [stockData.isin]: {
-      ...state.instruments[stockData.isin],
-      stockData,
-      subscribed: true,
-    },
-  },
-});
+): ListState => {
+  const instrumentExists = !!state.instruments[stockData.isin];
+
+  if (!instrumentExists) {
+    return state;
+  }
+
+  return {
+    ...state,
+    instruments: {
+      ...state.instruments,
+      [stockData.isin]: {
+        ...state.instruments[stockData.isin],
+        stockData,
+        subscribed: true,
+      }
+    }
+  }
+}
 
 export const handleUpdateInstrumentsSubscribed = (
   state: ListState,
@@ -125,18 +133,20 @@ export const handleUpdateInstrumentsSubscribed = (
 ): ListState => {
   const { instruments } = state;
   const unsubscribed: Instruments = Object.values(instruments)
-    .map((instrument: Instrument): Instrument => ({ ...instrument, subscribed }))
-    .reduce((acc: Instruments, curr: Instrument ): Instruments => {
+    .map(
+      (instrument: Instrument): Instrument => ({ ...instrument, subscribed })
+    )
+    .reduce((acc: Instruments, curr: Instrument): Instruments => {
       return {
         ...acc,
-        [curr.company.isin]: curr
-      } 
+        [curr.company.isin]: curr,
+      };
     }, {});
-  
+
   return {
     ...state,
-    instruments: unsubscribed
-  }
+    instruments: unsubscribed,
+  };
 };
 
 export const handleAddInstrument = (
@@ -165,13 +175,15 @@ export const handleAddInstrument = (
 
 export const handleRemoveInstrument = (
   state: ListState,
-  company: Company
+  { isin }: Company
 ): ListState => {
-  delete state.instruments[company.isin];
+  const newInstruments: Instruments = { ...state.instruments };
+
+  delete newInstruments[isin];
 
   return {
     ...state,
-    instruments: { ...state.instruments },
+    instruments: newInstruments,
   };
 };
 


### PR DESCRIPTION
**What is this?**

This PR fixes an issue where the app would crash when instruments that were unsubscribed from when offline would cause the app to crash, because updates were being passed to them when the app came back online.

An attempt to update stock data for an instrument that had subsequently been deleted would be made.

This is because the call to unsubscribe to the WebSocket server would not be received when offline, and a flurry of updates would come through when the connection was restored.