### PR TITLE
test: tidy up test mock data and restore further coverage

### DIFF
--- a/src/mocks/mockState.ts
+++ b/src/mocks/mockState.ts
@@ -1,0 +1,24 @@
+import { CombinedAppState } from '../store.types';
+import { BannerType } from '../services/notification-banner/banner.state.types';
+
+const mockState: CombinedAppState = {
+  search: {
+    companies: [],
+    searchTerm: '',
+  },
+  list: {
+    instruments: {},
+  },
+  connection: {
+    connected: false,
+    error: null,
+    socket: null,
+    listening: false,
+  },
+  banner: {
+    type: BannerType.SUCCESS,
+    isShowing: false
+  }
+};
+
+export default mockState;

--- a/src/services/connection/connection.state.test.ts
+++ b/src/services/connection/connection.state.test.ts
@@ -1,7 +1,6 @@
-import { CombinedAppState } from '../../store.types';
 import { ConnectionState } from './connection.state.types';
-import { BannerType } from '../notification-banner/banner.state.types';
 import connectionState from './connection.state';
+import mockState from '../../mocks/mockState';
 
 describe('connection state', (): void => {
   const dummyState: ConnectionState = {
@@ -207,40 +206,20 @@ describe('connection state', (): void => {
   });
 
   describe('selectors', (): void => {
-    const appState: CombinedAppState = {
-      search: {
-        companies: [],
-        searchTerm: '',
-      },
-      list: {
-        instruments: {},
-      },
-      connection: {
-        connected: false,
-        error: null,
-        socket: null,
-        listening: false,
-      },
-      banner: {
-        type: BannerType.SUCCESS,
-        isShowing: false,
-      },
-    };
-
     it('getSocket', (): void => {
-      expect(connectionState.selectors.getSocket(appState)).toBeNull();
+      expect(connectionState.selectors.getSocket(mockState)).toBeNull();
     });
 
     it('getIsConnected', (): void => {
-      expect(connectionState.selectors.getIsConnected(appState)).toEqual(false);
+      expect(connectionState.selectors.getIsConnected(mockState)).toEqual(false);
     });
 
     it('getError', (): void => {
-      expect(connectionState.selectors.getError(appState)).toBeNull();
+      expect(connectionState.selectors.getError(mockState)).toBeNull();
     });
 
     it('getIsListening', (): void => {
-      expect(connectionState.selectors.getIsListening(appState)).toEqual(false);
+      expect(connectionState.selectors.getIsListening(mockState)).toEqual(false);
     });
   });
 });

--- a/src/services/isin-list/list.saga.test.ts
+++ b/src/services/isin-list/list.saga.test.ts
@@ -1,66 +1,101 @@
+import { END } from 'redux-saga';
 import { delay, select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 
-import { CombinedAppState } from '../../store.types';
-
 import listState from './list.state';
-import { BannerType } from '../notification-banner/banner.state.types';
-import { Instrument } from './list.state.types';
+import { Instrument, StockData } from './list.state.types';
 import { Company } from '../isin-search/search.state.types';
 import connectionState from '../connection/connection.state';
-import rootSaga from './list.saga';
+import rootSaga, { eventChannelEmitter } from './list.saga';
 
-const mockState: CombinedAppState = {
-  search: {
-    companies: [],
-    searchTerm: '',
-  },
-  list: {
-    instruments: {},
-  },
-  connection: {
-    connected: false,
-    error: null,
-    socket: null,
-    listening: false,
-  },
-  banner: {
-    type: BannerType.SUCCESS,
-    isShowing: false
-  }
-};
+import mockState from '../../mocks/mockState';
 
 const company: Company = {
   name: 'Saga',
   shortName: 'SAG',
   isin: 'SAG123',
   bookmarked: false,
-}
+};
+
+const stockData: StockData = {
+  bid: 1.0,
+  ask: 0.9,
+  price: 1.1,
+  isin: 'SAG123',
+};
 
 const instrument: Instrument = {
   company,
-  stockData: {
-    bid: 1.0,
-    ask: 0.9,
-    price: 1.1,
-    isin: 'SAG123',
-  },
+  stockData,
   subscribed: false,
 };
 
 const spySend = jest.fn();
 const spyAddEventListener = jest.fn();
+const spyRemoveEventListener = jest.fn();
 
 const dummySocket: WebSocket = {
   send: spySend,
   addEventListener: spyAddEventListener,
+  removeEventListener: spyRemoveEventListener,
 } as unknown as WebSocket;
 
 describe('list saga', (): void => {
   afterEach((): void => {
     spySend.mockClear();
-    spyAddEventListener.mockClear();
+    spyAddEventListener.mockReset();
+  });
+
+  describe('eventChannelEmitter', (): void => {
+    it('adds the correct event listeners and calls END', (): void => {
+      const spyEmit = jest.fn();
+
+      eventChannelEmitter(spyEmit, dummySocket, company)();
+
+      expect(spyAddEventListener).toHaveBeenCalledTimes(1);
+      expect(spyAddEventListener).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+
+      expect(spySend).toHaveBeenCalledTimes(1);
+      expect(spySend).toHaveBeenCalledWith(
+        JSON.stringify({ subscribe: 'SAG123' })
+      );
+
+      expect(spyRemoveEventListener).toHaveBeenCalledTimes(1);
+      expect(spyRemoveEventListener).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+
+      expect(spyEmit).toHaveBeenCalledTimes(2);
+      expect(spyEmit).toHaveBeenNthCalledWith(
+        1,
+        connectionState.actions.setIsListening(false)
+      );
+      expect(spyEmit).toHaveBeenNthCalledWith(2, END);
+    });
+
+    it('emits the correct action on socket message', (): void => {
+      const spyEmit = jest.fn();
+
+      (spyAddEventListener as jest.Mock).mockImplementation(
+        (name: string, cb: ({ data }: { data: unknown }) => void): void => {
+          expect(name).toEqual('message');
+          cb({ data: JSON.stringify(stockData) });
+        }
+      );
+
+      eventChannelEmitter(spyEmit, dummySocket, company);
+
+      expect(spyEmit).toHaveBeenCalledTimes(1);
+      expect(spyEmit).toHaveBeenNthCalledWith(
+        1,
+        listState.actions.updateInstrument(stockData)
+      );
+    });
   });
 
   it('handleUnsubscribeInstrument', async (): Promise<void> => {
@@ -68,14 +103,16 @@ describe('list saga', (): void => {
       .withState(mockState)
       .provide([
         [select(connectionState.selectors.getSocket), dummySocket],
-        [matchers.call.fn(delay), null]
+        [matchers.call.fn(delay), null],
       ])
       .put(listState.actions.removeInstrument(company))
       .dispatch(listState.actions.unsubscribe(company))
       .silentRun();
-    
+
     expect(spySend).toHaveBeenCalledTimes(1);
-    expect(spySend).toHaveBeenCalledWith(JSON.stringify({ unsubscribe: 'SAG123' }));
+    expect(spySend).toHaveBeenCalledWith(
+      JSON.stringify({ unsubscribe: 'SAG123' })
+    );
   });
 
   it('handleUnsubscribeAllInstruments', async (): Promise<void> => {
@@ -86,29 +123,27 @@ describe('list saga', (): void => {
           instruments: {
             ['SAG123']: {
               ...instrument,
-              subscribed: true
-            }
-          }
-        }
+              subscribed: true,
+            },
+          },
+        },
       })
-      .provide([
-        [select(connectionState.selectors.getSocket), dummySocket]
-      ])
+      .provide([[select(connectionState.selectors.getSocket), dummySocket]])
       .select(listState.selectors.getSubscribedInstrumentIsins)
       .put(listState.actions.updateInstrumentSubscriptions(false))
       .dispatch(listState.actions.unsubscribeAll())
       .silentRun();
 
     expect(spySend).toHaveBeenCalledTimes(1);
-    expect(spySend).toHaveBeenCalledWith(JSON.stringify({ unsubscribe: 'SAG123' }));
+    expect(spySend).toHaveBeenCalledWith(
+      JSON.stringify({ unsubscribe: 'SAG123' })
+    );
   });
 
   it('handleOnInstrumentAdded', async (): Promise<void> => {
     await expectSaga(rootSaga)
       .withState(mockState)
-      .provide([
-        [select(connectionState.selectors.getSocket), dummySocket],
-      ])
+      .provide([[select(connectionState.selectors.getSocket), dummySocket]])
       // .call(subscribe, dummySocket, company) TODO: fix
       .dispatch(listState.actions.addInstrument(company))
       .silentRun();
@@ -120,19 +155,19 @@ describe('list saga', (): void => {
         ...mockState,
         list: {
           instruments: {
-            ['SAG123']: instrument
-          }
-        }
+            ['SAG123']: instrument,
+          },
+        },
       })
-      .provide([
-        [select(connectionState.selectors.getSocket), dummySocket],
-      ])
+      .provide([[select(connectionState.selectors.getSocket), dummySocket]])
       .select(listState.selectors.getUnsubscribedInstrumentIsins)
       .put(listState.actions.updateInstrumentSubscriptions(true))
       .dispatch(listState.actions.resubscribeAll())
       .silentRun();
 
     expect(spySend).toHaveBeenCalledTimes(1);
-    expect(spySend).toHaveBeenCalledWith(JSON.stringify({ subscribe: 'SAG123' }));
+    expect(spySend).toHaveBeenCalledWith(
+      JSON.stringify({ subscribe: 'SAG123' })
+    );
   });
 });

--- a/src/services/isin-list/list.state.test.ts
+++ b/src/services/isin-list/list.state.test.ts
@@ -1,7 +1,7 @@
 import { CombinedAppState } from '../../store.types';
 import { Company } from '../isin-search/search.state.types';
 import { Instrument, ListState, StockData } from './list.state.types';
-import { BannerType } from '../notification-banner/banner.state.types';
+import mockState from '../../mocks/mockState';
 import listState, {
   handleAddInstrument,
   handleRemoveInstrument,
@@ -267,24 +267,11 @@ describe('list state', (): void => {
 
   describe('selectors', (): void => {
     const appState: CombinedAppState = {
-      search: {
-        companies: [],
-        searchTerm: '',
-      },
+      ...mockState,
       list: {
         instruments: {
           ['IE123456']: instrument,
         },
-      },
-      connection: {
-        connected: false,
-        error: null,
-        socket: null,
-        listening: false,
-      },
-      banner: {
-        type: BannerType.SUCCESS,
-        isShowing: false,
       },
     };
 

--- a/src/services/isin-search/search.state.test.ts
+++ b/src/services/isin-search/search.state.test.ts
@@ -1,9 +1,10 @@
 import isins from '../../assets/isins.json';
 
 import { CombinedAppState } from '../../store.types';
-import { BannerType } from '../notification-banner/banner.state.types';
 import searchState from './search.state';
 import { Company, SearchAction, SearchState } from './search.state.types';
+
+import mockState from '../../mocks/mockState';
 
 describe('search state', (): void => {
   describe('actions', (): void => {
@@ -78,23 +79,11 @@ describe('search state', (): void => {
       { name: 'Company two', shortName: 'TWO', isin: 'IE2', bookmarked: false },
     ];
     const appState: CombinedAppState = {
+      ...mockState,
       search: {
         companies,
         searchTerm,
       },
-      list: {
-        instruments: {},
-      },
-      connection: {
-        connected: false,
-        error: null,
-        socket: null,
-        listening: false,
-      },
-      banner: {
-        type: BannerType.SUCCESS,
-        isShowing: false
-      }
     };
 
     it('getSearchTerm', (): void => {
@@ -102,13 +91,15 @@ describe('search state', (): void => {
     });
 
     it('getCompanies', (): void => {
-      expect(searchState.selectors.getCompanies({
-        ...appState,
-        search: {
-          companies,
-          searchTerm: 'one'
-        }
-      })).toEqual([companies[0]]);
+      expect(
+        searchState.selectors.getCompanies({
+          ...appState,
+          search: {
+            companies,
+            searchTerm: 'one',
+          },
+        })
+      ).toEqual([companies[0]]);
     });
   });
 });

--- a/src/services/notification-banner/banner.saga.test.ts
+++ b/src/services/notification-banner/banner.saga.test.ts
@@ -1,29 +1,10 @@
 import { expectSaga } from 'redux-saga-test-plan';
 
-import { CombinedAppState } from '../../store.types';
 import { BannerType } from '../notification-banner/banner.state.types';
 import bannerState from './banner.state';
 import rootSaga from './banner.saga';
 
-const mockState: CombinedAppState = {
-  search: {
-    companies: [],
-    searchTerm: '',
-  },
-  list: {
-    instruments: {},
-  },
-  connection: {
-    connected: false,
-    error: null,
-    socket: null,
-    listening: false,
-  },
-  banner: {
-    type: BannerType.SUCCESS,
-    isShowing: false
-  }
-};
+import mockState from '../../mocks/mockState';
 
 describe('banner saga', (): void => {
   it('should handle showing then hiding the banner', async (): Promise<void> => {

--- a/src/services/notification-banner/banner.state.test.ts
+++ b/src/services/notification-banner/banner.state.test.ts
@@ -1,5 +1,6 @@
 import { CombinedAppState } from '../../store.types';
 import { BannerState, BannerType } from './banner.state.types';
+import mockState from '../../mocks/mockState';
 import bannerState from './banner.state';
 
 describe('banner state', (): void => {
@@ -80,19 +81,7 @@ describe('banner state', (): void => {
 
   describe('selectors', (): void => {
     const appState: CombinedAppState = {
-      search: {
-        companies: [],
-        searchTerm: ''
-      },
-      list: {
-        instruments: {},
-      },
-      connection: {
-        connected: false,
-        error: null,
-        socket: null,
-        listening: false,
-      },
+      ...mockState,
       banner: {
         type: BannerType.SUCCESS,
         isShowing: false,


### PR DESCRIPTION
**What is this?**

This PR restores further test coverage and checks event channels in redux sagas, exposing them so they can be tested more easily.

The mockState used across several tests has also been abstracted, so it's not repeated across several tests. It can be imported and overridden for specific tests.