### PR TITLE
fix: use path aliases for imports

### DIFF
--- a/src/components/instrument/instrument.css.tsx
+++ b/src/components/instrument/instrument.css.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-import { fonts, fontWeights } from '../../styles/vars';
-import { font } from '../../styles/mixins';
-import { Thrash } from '../svg';
+import { fonts, fontWeights } from 'styles/vars';
+import { font } from 'styles/mixins';
+import { Thrash } from 'components/svg';
 
 export const Container = styled.li`
   position: relative;

--- a/src/components/instrument/instrument.test.tsx
+++ b/src/components/instrument/instrument.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 
-import { Company } from '../../services/isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 import InstrumentTile, { Props } from './instrument';
 
 const company: Company = {

--- a/src/components/instrument/instrument.tsx
+++ b/src/components/instrument/instrument.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 
-import { formattedCurrency } from '../../utils';
+import { formattedCurrency } from 'utils';
 
-import { Company } from '../../services/isin-search/search.state.types';
-import { Instrument } from '../../services/isin-list/list.state.types';
+import { Company } from 'services/isin-search/search.state.types';
+import { Instrument } from 'services/isin-list/list.state.types';
 import {
   Container,
   CompanyInfo,

--- a/src/components/notification-banner/banner.css.tsx
+++ b/src/components/notification-banner/banner.css.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import { BannerType } from '../../services/notification-banner/banner.state.types';
-import { font } from '../../styles/mixins';
-import { colours, fonts } from '../../styles/vars';
+import { BannerType } from 'services/notification-banner/banner.state.types';
+import { font } from 'styles/mixins';
+import { colours, fonts } from 'styles/vars';
 
 interface ContainerProps {
   isShowing: boolean;

--- a/src/components/notification-banner/banner.test.tsx
+++ b/src/components/notification-banner/banner.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import 'jest-styled-components';
 import { render } from '@testing-library/react';
 
-import { BannerType } from '../../services/notification-banner/banner.state.types';
+import { BannerType } from 'services/notification-banner/banner.state.types';
 import { Banner, Props } from './banner';
 
 const defaultProps: Props = {

--- a/src/components/notification-banner/banner.tsx
+++ b/src/components/notification-banner/banner.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { CombinedAppState } from '../../store.types';
-import bannerState from '../../services/notification-banner/banner.state';
-import { BannerType } from '../../services/notification-banner/banner.state.types';
+import { CombinedAppState } from 'store.types';
+import bannerState from 'services/notification-banner/banner.state';
+import { BannerType } from 'services/notification-banner/banner.state.types';
 import { Container, Message } from './banner.css';
 
 export interface Props {

--- a/src/components/search-result/search-result.css.tsx
+++ b/src/components/search-result/search-result.css.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
-import { fonts } from '../../styles/vars';
-import { font } from '../../styles/mixins';
+import { fonts } from 'styles/vars';
+import { font } from 'styles/mixins';
 
 import { Bookmark, BookmarkFilled } from '../svg';
 

--- a/src/components/search-result/search-result.test.tsx
+++ b/src/components/search-result/search-result.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { Company } from '../../services/isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 import SearchResult, { Props } from './search-result';
 
 const defaultProps: Props = {

--- a/src/components/search-result/search-result.tsx
+++ b/src/components/search-result/search-result.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 
-import { Company } from '../../services/isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 import { BookmarkIcon, BookmarkFilledIcon, Container, CompanyDetails, Title } from './search-result.css';
 
 export interface Props {

--- a/src/mocks/mockState.ts
+++ b/src/mocks/mockState.ts
@@ -1,5 +1,5 @@
-import { CombinedAppState } from '../store.types';
-import { BannerType } from '../services/notification-banner/banner.state.types';
+import { CombinedAppState } from 'store.types';
+import { BannerType } from 'services/notification-banner/banner.state.types';
 
 const mockState: CombinedAppState = {
   search: {

--- a/src/services/connection/connection.saga.test.ts
+++ b/src/services/connection/connection.saga.test.ts
@@ -5,10 +5,10 @@ import { throwError } from 'redux-saga-test-plan/providers';
 
 import connectionState from './connection.state';
 import rootSaga, { openSocket, closeSocket, monitorConnection, eventChannelEmitter } from './connection.saga';
-import { BannerType } from '../notification-banner/banner.state.types';
-import bannerState from '../notification-banner/banner.state';
+import { BannerType } from 'services/notification-banner/banner.state.types';
+import bannerState from 'services/notification-banner/banner.state';
 
-import mockState from '../../mocks/mockState';
+import mockState from 'mocks/mockState';
 import { waitFor } from '@testing-library/react';
 
 const dummySocket: WebSocket = {

--- a/src/services/connection/connection.saga.ts
+++ b/src/services/connection/connection.saga.ts
@@ -1,10 +1,10 @@
 import { all, call, select, put, takeLatest, take } from 'redux-saga/effects';
 import { eventChannel, EventChannel, END } from 'redux-saga';
 
-import Config from '../../config';
+import Config from 'config';
 
-import bannerState from '../notification-banner/banner.state';
-import { BannerType } from '../notification-banner/banner.state.types';
+import bannerState from 'services/notification-banner/banner.state';
+import { BannerType } from 'services/notification-banner/banner.state.types';
 import connectionState from './connection.state';
 import { ConnectionAction } from './connection.state.types';
 

--- a/src/services/connection/connection.state.test.ts
+++ b/src/services/connection/connection.state.test.ts
@@ -1,6 +1,6 @@
 import { ConnectionState } from './connection.state.types';
 import connectionState from './connection.state';
-import mockState from '../../mocks/mockState';
+import mockState from 'mocks/mockState';
 
 describe('connection state', (): void => {
   const dummyState: ConnectionState = {

--- a/src/services/isin-list/list.saga.test.ts
+++ b/src/services/isin-list/list.saga.test.ts
@@ -5,11 +5,11 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 
 import listState from './list.state';
 import { Instrument, StockData } from './list.state.types';
-import { Company } from '../isin-search/search.state.types';
-import connectionState from '../connection/connection.state';
+import { Company } from 'services/isin-search/search.state.types';
+import connectionState from 'services/connection/connection.state';
 import rootSaga, { eventChannelEmitter } from './list.saga';
 
-import mockState from '../../mocks/mockState';
+import mockState from 'mocks/mockState';
 
 const company: Company = {
   name: 'Saga',

--- a/src/services/isin-list/list.saga.ts
+++ b/src/services/isin-list/list.saga.ts
@@ -9,13 +9,13 @@ import {
 } from 'redux-saga/effects';
 import { END, eventChannel, EventChannel } from 'redux-saga';
 
-import { Company } from '../isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 import { ListAction, StockData } from './list.state.types';
-import { BannerType } from '../notification-banner/banner.state.types';
-import connectionState from '../connection/connection.state';
+import { BannerType } from 'services/notification-banner/banner.state.types';
+import connectionState from 'services/connection/connection.state';
 import listState from './list.state';
-import bannerState from '../notification-banner/banner.state';
-import { ConnectionAction } from '../connection/connection.state.types';
+import bannerState from 'services/notification-banner/banner.state';
+import { ConnectionAction } from 'services/connection/connection.state.types';
 
 export const eventChannelEmitter = (
   emit: (action: ListAction | ConnectionAction) => void,

--- a/src/services/isin-list/list.state.test.ts
+++ b/src/services/isin-list/list.state.test.ts
@@ -1,7 +1,7 @@
 import { CombinedAppState } from '../../store.types';
-import { Company } from '../isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 import { Instrument, ListState, StockData } from './list.state.types';
-import mockState from '../../mocks/mockState';
+import mockState from 'mocks/mockState';
 import listState, {
   handleAddInstrument,
   handleRemoveInstrument,

--- a/src/services/isin-list/list.state.ts
+++ b/src/services/isin-list/list.state.ts
@@ -8,7 +8,7 @@ import {
   StockData,
 } from './list.state.types';
 
-import { Company } from '../isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 
 const REDUCER_NAME = `list`;
 

--- a/src/services/isin-list/list.state.types.ts
+++ b/src/services/isin-list/list.state.types.ts
@@ -1,4 +1,4 @@
-import { Company } from '../isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 
 export interface StockData {
   ask: number;

--- a/src/services/isin-search/search.state.test.ts
+++ b/src/services/isin-search/search.state.test.ts
@@ -1,10 +1,10 @@
-import isins from '../../assets/isins.json';
+import isins from 'assets/isins.json';
 
-import { CombinedAppState } from '../../store.types';
+import { CombinedAppState } from 'store.types';
 import searchState from './search.state';
 import { Company, SearchAction, SearchState } from './search.state.types';
 
-import mockState from '../../mocks/mockState';
+import mockState from 'mocks/mockState';
 
 describe('search state', (): void => {
   describe('actions', (): void => {

--- a/src/services/isin-search/search.state.ts
+++ b/src/services/isin-search/search.state.ts
@@ -1,7 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 
-import isins from '../../assets/isins.json';
-import listState from '../isin-list/list.state';
+import isins from 'assets/isins.json';
+import listState from 'services/isin-list/list.state';
 
 import { Company, SearchAction, SearchState } from './search.state.types';
 

--- a/src/services/notification-banner/banner.saga.test.ts
+++ b/src/services/notification-banner/banner.saga.test.ts
@@ -1,10 +1,10 @@
 import { expectSaga } from 'redux-saga-test-plan';
 
-import { BannerType } from '../notification-banner/banner.state.types';
+import { BannerType } from 'services/notification-banner/banner.state.types';
 import bannerState from './banner.state';
 import rootSaga from './banner.saga';
 
-import mockState from '../../mocks/mockState';
+import mockState from 'mocks/mockState';
 
 describe('banner saga', (): void => {
   it('should handle showing then hiding the banner', async (): Promise<void> => {

--- a/src/services/notification-banner/banner.state.test.ts
+++ b/src/services/notification-banner/banner.state.test.ts
@@ -1,6 +1,6 @@
-import { CombinedAppState } from '../../store.types';
+import { CombinedAppState } from 'store.types';
 import { BannerState, BannerType } from './banner.state.types';
-import mockState from '../../mocks/mockState';
+import mockState from 'mocks/mockState';
 import bannerState from './banner.state';
 
 describe('banner state', (): void => {

--- a/src/views/isin-list/list.css.tsx
+++ b/src/views/isin-list/list.css.tsx
@@ -1,10 +1,10 @@
 import styled, { css } from 'styled-components'
 
-import { boxShadow, fonts } from '../../styles/vars';
-import { font, media } from '../../styles/mixins';
+import { boxShadow, fonts } from 'styles/vars';
+import { font, media } from 'styles/mixins';
 
-import InstrumentTile from '../../components/instrument/instrument';
-import { CompanyMetadata, PriceInfo, PriceItem, Price } from '../../components/instrument/instrument.css';
+import InstrumentTile from 'components/instrument/instrument';
+import { CompanyMetadata, PriceInfo, PriceItem, Price } from 'components/instrument/instrument.css';
 
 export const Container = styled.div`
   display: grid;

--- a/src/views/isin-list/list.test.tsx
+++ b/src/views/isin-list/list.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 
-import { Instrument } from '../../services/isin-list/list.state.types';
+import { Instrument } from 'services/isin-list/list.state.types';
 
 import { List, Props } from './list';
 

--- a/src/views/isin-list/list.tsx
+++ b/src/views/isin-list/list.tsx
@@ -1,11 +1,11 @@
 import React, { memo, useEffect } from 'react';
 import { connect } from 'react-redux';
 
-import { CombinedAppState } from '../../store.types';
-import ListState from '../../services/isin-list/list.state';
-import { Company } from '../../services/isin-search/search.state.types';
-import { Instrument } from '../../services/isin-list/list.state.types';
-import { Props as InstrumentTileProps } from '../../components/instrument/instrument';
+import { CombinedAppState } from 'store.types';
+import ListState from 'services/isin-list/list.state';
+import { Company } from 'services/isin-search/search.state.types';
+import { Instrument } from 'services/isin-list/list.state.types';
+import { Props as InstrumentTileProps } from 'components/instrument/instrument';
 
 import {
   Container,

--- a/src/views/isin-search/search.css.tsx
+++ b/src/views/isin-search/search.css.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 
-import { boxShadow, colours, fonts } from '../../styles/vars';
-import { font } from '../../styles/mixins';
-import TextInput from '../../components/text-input';
-import SearchResult from '../../components/search-result';
+import { boxShadow, colours, fonts } from 'styles/vars';
+import { font } from 'styles/mixins';
+import TextInput from 'components/text-input';
+import SearchResult from 'components/search-result';
 
 export const Container = styled.div`
   display: grid;

--- a/src/views/isin-search/search.test.tsx
+++ b/src/views/isin-search/search.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 
-import { Company } from '../../services/isin-search/search.state.types';
+import { Company } from 'services/isin-search/search.state.types';
 import { Search, Props } from './search';
 
 const defaultProps: Props = {

--- a/src/views/isin-search/search.tsx
+++ b/src/views/isin-search/search.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useState, memo } from 'react';
 import { connect } from 'react-redux';
 
-import { CombinedAppState } from '../../store.types';
-import SearchState from '../../services/isin-search/search.state';
-import ListState from '../../services/isin-list/list.state';
-import { Company } from '../../services/isin-search/search.state.types';
-import { Props as SearchResultProps } from '../../components/search-result/search-result';
+import { CombinedAppState } from 'store.types';
+import SearchState from 'services/isin-search/search.state';
+import ListState from 'services/isin-list/list.state';
+import { Company } from 'services/isin-search/search.state.types';
+import { Props as SearchResultProps } from 'components/search-result/search-result';
 
 import {
   Container,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "src",
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
**What is this?**

This PR tidies up path imports and makes better use given create-react-app v3 supports path aliasing out of the box.