### PR TITLE
feat: handle resubscribe on server connection loss

### DIFF
--- a/src/services/connection/connection.state.test.ts
+++ b/src/services/connection/connection.state.test.ts
@@ -195,6 +195,16 @@ describe('connection state', (): void => {
       expect(result).toEqual(expected);
     });
 
+    it('sets the state with RESET_CONECTION', (): void => {
+      const expected: ConnectionState = dummyState;
+      const result: ConnectionState = connectionState.reducer(
+        dummyState,
+        connectionState.actions.resetConnection()
+      );
+
+      expect(result).toEqual(expected);
+    });
+
     it('returns the default state with no type match', (): void => {
       const expected: ConnectionState = dummyState;
       const result: ConnectionState = connectionState.reducer(undefined, {

--- a/src/services/connection/connection.state.ts
+++ b/src/services/connection/connection.state.ts
@@ -14,6 +14,7 @@ const CLOSE_CONNECTION_FAILURE = `${REDUCER_NAME}/CLOSE_CONNECTION_FAILURE`;
 const SET_IS_LISTENING = `${REDUCER_NAME}/SET_IS_LISTENING`;
 const CONNECTION_OFFLINE = `${REDUCER_NAME}/CONNECTION_OFFLINE`;
 const CONNECTION_ONLINE = `${REDUCER_NAME}/CONNECTION_ONLINE`;
+const RESET_CONNECTION = `${REDUCER_NAME}/RESET_CONNECTION`;
 
 /** Actions */
 const openConnectionRequest = (): ConnectionAction => ({
@@ -55,6 +56,10 @@ const connectionOffline = (): ConnectionAction => ({
 
 const connectionOnline = (): ConnectionAction => ({
   type: CONNECTION_ONLINE,
+});
+
+const resetConnection = (): ConnectionAction => ({
+  type: RESET_CONNECTION
 });
 
 const setIsListening = (listening: boolean): ConnectionAction => ({
@@ -122,6 +127,9 @@ const reducer = (
         listening: payload!.listening!
       };
     }
+    case RESET_CONNECTION: {
+      return initialState;
+    }
     default:
       return state;
   }
@@ -185,6 +193,7 @@ const connectionState = {
     SET_IS_LISTENING,
     CONNECTION_OFFLINE,
     CONNECTION_ONLINE,
+    RESET_CONNECTION,
   },
   selectors: {
     getSocket: selectSocket,
@@ -202,6 +211,7 @@ const connectionState = {
     setIsListening,
     connectionOffline,
     connectionOnline,
+    resetConnection,
   },
 };
 

--- a/src/services/isin-list/list.saga.test.ts
+++ b/src/services/isin-list/list.saga.test.ts
@@ -1,7 +1,6 @@
 import { END } from 'redux-saga';
-import { delay, select } from 'redux-saga/effects';
+import { select } from 'redux-saga/effects';
 import { expectSaga } from 'redux-saga-test-plan';
-import * as matchers from 'redux-saga-test-plan/matchers';
 
 import listState from './list.state';
 import { Instrument, StockData } from './list.state.types';
@@ -10,6 +9,8 @@ import connectionState from 'services/connection/connection.state';
 import rootSaga, { eventChannelEmitter } from './list.saga';
 
 import mockState from 'mocks/mockState';
+import bannerState from 'services/notification-banner/banner.state';
+import { BannerType } from 'services/notification-banner/banner.state.types';
 
 const company: Company = {
   name: 'Saga',
@@ -51,17 +52,12 @@ describe('list saga', (): void => {
     it('adds the correct event listeners and calls END', (): void => {
       const spyEmit = jest.fn();
 
-      eventChannelEmitter(spyEmit, dummySocket, company)();
+      eventChannelEmitter(spyEmit, dummySocket)();
 
       expect(spyAddEventListener).toHaveBeenCalledTimes(1);
       expect(spyAddEventListener).toHaveBeenCalledWith(
         'message',
         expect.any(Function)
-      );
-
-      expect(spySend).toHaveBeenCalledTimes(1);
-      expect(spySend).toHaveBeenCalledWith(
-        JSON.stringify({ subscribe: 'SAG123' })
       );
 
       expect(spyRemoveEventListener).toHaveBeenCalledTimes(1);
@@ -70,12 +66,8 @@ describe('list saga', (): void => {
         expect.any(Function)
       );
 
-      expect(spyEmit).toHaveBeenCalledTimes(2);
-      expect(spyEmit).toHaveBeenNthCalledWith(
-        1,
-        connectionState.actions.setIsListening(false)
-      );
-      expect(spyEmit).toHaveBeenNthCalledWith(2, END);
+      expect(spyEmit).toHaveBeenCalledTimes(1);
+      expect(spyEmit).toHaveBeenCalledWith(END);
     });
 
     it('emits the correct action on socket message', (): void => {
@@ -88,31 +80,52 @@ describe('list saga', (): void => {
         }
       );
 
-      eventChannelEmitter(spyEmit, dummySocket, company);
+      eventChannelEmitter(spyEmit, dummySocket);
 
       expect(spyEmit).toHaveBeenCalledTimes(1);
-      expect(spyEmit).toHaveBeenNthCalledWith(
-        1,
+      expect(spyEmit).toHaveBeenCalledWith(
         listState.actions.updateInstrument(stockData)
       );
     });
   });
 
-  it('handleUnsubscribeInstrument', async (): Promise<void> => {
-    await expectSaga(rootSaga)
-      .withState(mockState)
-      .provide([
-        [select(connectionState.selectors.getSocket), dummySocket],
-        [matchers.call.fn(delay), null],
-      ])
-      .put(listState.actions.removeInstrument(company))
-      .dispatch(listState.actions.unsubscribe(company))
-      .silentRun();
+  describe('handleInstrumentUnsubscribe', (): void => {
+    it('unsubscribes with success', async (): Promise<void> => {
+      await expectSaga(rootSaga)
+        .withState(mockState)
+        .provide([
+          [select(connectionState.selectors.getSocket), dummySocket]
+        ])
+        .put(bannerState.actions.showBanner('Unsubscribed successfully and removed!', BannerType.SUCCESS, 2000))
+        .put(listState.actions.removeInstrument(company))
+        .dispatch(listState.actions.unsubscribe(company))
+        .silentRun();
+  
+      expect(spySend).toHaveBeenCalledTimes(1);
+      expect(spySend).toHaveBeenCalledWith(
+        JSON.stringify({ unsubscribe: 'SAG123' })
+      );
+    });
 
-    expect(spySend).toHaveBeenCalledTimes(1);
-    expect(spySend).toHaveBeenCalledWith(
-      JSON.stringify({ unsubscribe: 'SAG123' })
-    );
+    it('fails to unsubscribe', async (): Promise<void> => {
+      (spySend as jest.Mock).mockImplementation((): void => {
+        throw new Error('oops');
+      });
+
+      await expectSaga(rootSaga)
+        .withState(mockState)
+        .provide([
+          [select(connectionState.selectors.getSocket), dummySocket]
+        ])
+        .put(bannerState.actions.showBanner('Could not unsubscribe from server!', BannerType.ERROR, 2000))
+        .dispatch(listState.actions.unsubscribe(company))
+        .silentRun();
+  
+      expect(spySend).toHaveBeenCalledTimes(1);
+      expect(spySend).toHaveBeenCalledWith(
+        JSON.stringify({ unsubscribe: 'SAG123' })
+      );
+    });
   });
 
   it('handleUnsubscribeAllInstruments', async (): Promise<void> => {
@@ -144,9 +157,14 @@ describe('list saga', (): void => {
     await expectSaga(rootSaga)
       .withState(mockState)
       .provide([[select(connectionState.selectors.getSocket), dummySocket]])
-      // .call(subscribe, dummySocket, company) TODO: fix
+      .put(bannerState.actions.showBanner('Subscription successful!', BannerType.SUCCESS, 2000))
       .dispatch(listState.actions.addInstrument(company))
       .silentRun();
+
+    expect(spySend).toHaveBeenCalledTimes(1);
+    expect(spySend).toHaveBeenCalledWith(
+      JSON.stringify({ subscribe: 'SAG123' })
+    );
   });
 
   it('handleResubscribeAllInstruments', async (): Promise<void> => {
@@ -169,5 +187,13 @@ describe('list saga', (): void => {
     expect(spySend).toHaveBeenCalledWith(
       JSON.stringify({ subscribe: 'SAG123' })
     );
+  });
+
+  it('handleServerConnectionLost', async (): Promise<void> => {
+    await expectSaga(rootSaga)
+      .withState(mockState)
+      .put(listState.actions.updateInstrumentSubscriptions(false))
+      .dispatch(connectionState.actions.resetConnection())
+      .silentRun();
   });
 });


### PR DESCRIPTION
**What is this?**
This PR improves the recover mechanism for when the connection to the WebSocket server goes down because the server has gone down.

When the server goes down, a repeated attempt to reconnect is made every 5 seconds indefinitely.

**Notes**
- When the connection to the server has been cut, any subscribed instruments will destroy any event listeners as a cleanup
- When the connection is restored, new event listeners are added.
- As an improvement, the list saga only adds one socket `message` event listener when a connection to the server has succeeded and a socket becomes available.
- This single event listener listens for all subscriptions, and emits a payload to the correct instrument by calling an action.
- This is a big improvement over previous functionality, where multiple `message` event listeners were created for each instrument added.
- Instruments will resume updating immediately as soon as the connection to the server is restored. 