### PR TITLE
fix: ensure connection event emitter cleanup on server connection drop

### DIFF
--- a/src/services/connection/connection.saga.test.ts
+++ b/src/services/connection/connection.saga.test.ts
@@ -6,7 +6,7 @@ import { throwError } from 'redux-saga-test-plan/providers';
 import Config from 'config';
 import { openSocket, closeSocket } from './socket';
 import connectionState from './connection.state';
-import rootSaga, { monitorConnection, eventChannelEmitter } from './connection.saga';
+import rootSaga, { setupSocketListeners, eventChannelEmitter } from './connection.saga';
 import { BannerType } from 'services/notification-banner/banner.state.types';
 import bannerState from 'services/notification-banner/banner.state';
 
@@ -154,8 +154,9 @@ describe('connection saga', (): void => {
     it('should show a success message and monitor the network on connection success', async (): Promise<void> => {
       await expectSaga(rootSaga)
         .withState(mockState)
-        .call(monitorConnection, dummySocket)
+        .call(setupSocketListeners, dummySocket)
         .put(bannerState.actions.showBanner('Connected successfully', BannerType.SUCCESS))
+        .take(connectionState.types.RESET_CONNECTION)
         .dispatch(connectionState.actions.openConnectionSuccess(dummySocket as WebSocket))
         .silentRun();
     });

--- a/src/services/isin-list/list.saga.ts
+++ b/src/services/isin-list/list.saga.ts
@@ -43,23 +43,25 @@ export function setupSocketListener (
   );
 }
 
+
+
 /* istanbul ignore next */
 function* handleConnectionSuccess(): Generator<unknown> {
   const socket = yield select(connectionState.selectors.getSocket);
   const channel = yield call(setupSocketListener, socket as WebSocket);
 
   while (true) {
-    const action: any = yield race({
-      refreshInstrument: take(channel as EventChannel<unknown>),
+    const { task, cancel }: any = yield race({
+      task: take(channel as EventChannel<ListAction>),
       cancel: take(connectionState.types.RESET_CONNECTION)
     });
 
-    if (action.cancel) {
-      (channel as EventChannel<unknown>).close();
+    if (cancel) {
+      (channel as EventChannel<ListAction>).close();
       break;
     }
 
-    yield put(action.refreshInstrument);
+    yield put(task);
   }
 }
 


### PR DESCRIPTION
**What is this?**

This PR fixes the connection saga, and ensures proper clean up when the event emitter has its channel closed.
